### PR TITLE
Namespace defines

### DIFF
--- a/pgbouncer/templates/_helpers.tpl
+++ b/pgbouncer/templates/_helpers.tpl
@@ -15,3 +15,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+The app label for the pgbouncer Deployment.  This is used as a selector for Pods in its Deployment.
+*/}}
+{{- define "pgbouncer.app-label" -}}
+app: {{ template "pgbouncer.fullname" . -}}
+{{- end -}}

--- a/pgbouncer/templates/_helpers.tpl
+++ b/pgbouncer/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "pgbouncer.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "pgbouncer.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/pgbouncer/templates/_helpers.tpl
+++ b/pgbouncer/templates/_helpers.tpl
@@ -18,6 +18,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{/*
 The app label for the pgbouncer Deployment.  This is used as a selector for Pods in its Deployment.
 */}}
-{{- define "pgbouncer.app-label" -}}
+{{- define "pgbouncer.appLabel" -}}
 app: {{ template "pgbouncer.fullname" . -}}
 {{- end -}}

--- a/pgbouncer/templates/deployment-pgbouncer.yaml
+++ b/pgbouncer/templates/deployment-pgbouncer.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "pgbouncer.fullname" . }}
   labels:
-    app: {{ template "pgbouncer.fullname" . }}
+    {{ template "pgbouncer.app-label" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -29,7 +29,7 @@ spec:
             - topologyKey: kubernetes.io/hostname
               labelSelector:
                 matchLabels:
-                  app: {{ template "pgbouncer.fullname" . }}
+                  {{ template "pgbouncer.app-label" . }}
                   release: {{ .Release.Name }}
         {{- else if eq .Values.antiAffinity "soft" }}
         podAntiAffinity:
@@ -39,7 +39,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
                 labelSelector:
                   matchLabels:
-                    app: {{ template "pgbouncer.fullname" . }}
+                    {{ template "pgbouncer.app-label" . }}
                     release: {{ .Release.Name }}
         {{- end }}
       imagePullSecrets:

--- a/pgbouncer/templates/deployment-pgbouncer.yaml
+++ b/pgbouncer/templates/deployment-pgbouncer.yaml
@@ -1,9 +1,9 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "pgbouncer.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "pgbouncer.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "pgbouncer.fullname" . }}
         release: {{ .Release.Name }}
     spec:
       affinity:
@@ -29,7 +29,7 @@ spec:
             - topologyKey: kubernetes.io/hostname
               labelSelector:
                 matchLabels:
-                  app: {{ template "fullname" . }}
+                  app: {{ template "pgbouncer.fullname" . }}
                   release: {{ .Release.Name }}
         {{- else if eq .Values.antiAffinity "soft" }}
         podAntiAffinity:
@@ -39,7 +39,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
                 labelSelector:
                   matchLabels:
-                    app: {{ template "fullname" . }}
+                    app: {{ template "pgbouncer.fullname" . }}
                     release: {{ .Release.Name }}
         {{- end }}
       imagePullSecrets:
@@ -47,7 +47,7 @@ spec:
       volumes:
         - name: secret
           secret:
-            secretName: {{ template "fullname" . }}-secret
+            secretName: {{ template "pgbouncer.fullname" . }}-secret
       containers:
         - name: pgbouncer
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/pgbouncer/templates/deployment-pgbouncer.yaml
+++ b/pgbouncer/templates/deployment-pgbouncer.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "pgbouncer.fullname" . }}
   labels:
-    {{ template "pgbouncer.app-label" . }}
+    {{ template "pgbouncer.appLabel" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -29,7 +29,7 @@ spec:
             - topologyKey: kubernetes.io/hostname
               labelSelector:
                 matchLabels:
-                  {{ template "pgbouncer.app-label" . }}
+                  {{ template "pgbouncer.appLabel" . }}
                   release: {{ .Release.Name }}
         {{- else if eq .Values.antiAffinity "soft" }}
         podAntiAffinity:
@@ -39,7 +39,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
                 labelSelector:
                   matchLabels:
-                    {{ template "pgbouncer.app-label" . }}
+                    {{ template "pgbouncer.appLabel" . }}
                     release: {{ .Release.Name }}
         {{- end }}
       imagePullSecrets:

--- a/pgbouncer/templates/pod-disruption-budget.yaml
+++ b/pgbouncer/templates/pod-disruption-budget.yaml
@@ -2,16 +2,16 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: "{{ template "fullname" . }}"
+  name: "{{ template "pgbouncer.fullname" . }}"
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "pgbouncer.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "fullname" . }}
+      app: {{ template "pgbouncer.fullname" . }}
       release: {{ .Release.Name }}
   minAvailable: {{ .Values.budget.minAvailable }}
 {{- end -}}

--- a/pgbouncer/templates/secret-pgbouncer-configfiles.yaml
+++ b/pgbouncer/templates/secret-pgbouncer-configfiles.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fullname" . }}-secret
+  name: {{ template "pgbouncer.fullname" . }}-secret
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "pgbouncer.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
this adds "pgbouncer." to beginning of define names.  also adds a new define "pgbouncer.app-label" which will output the entire "app: {{ template "pgbouncer.fullname" . }}" string - and deployment-pgbouncer.yaml is changed to use this new define.

the intent of "pgbouncer.app-label" is parent charts can use the define if they want to select the pgbouncer deployment pods.