### PR TITLE
Added a way to pass metadata labels to kube pod.

### DIFF
--- a/pgbouncer/templates/deployment-pgbouncer.yaml
+++ b/pgbouncer/templates/deployment-pgbouncer.yaml
@@ -24,6 +24,9 @@ spec:
       labels:
         app: {{ template "pgbouncer.fullname" . }}
         release: {{ .Release.Name }}
+        {{- if .Values.spec.labels }}
+        {{- toYaml .Values.spec.labels | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/ini: {{ include "pgbouncer.ini.1.0.0" . | sha256sum }}
         checksum/users: {{ include "userlist.txt.1.0.0" . | sha256sum }}

--- a/pgbouncer/values.yaml
+++ b/pgbouncer/values.yaml
@@ -28,6 +28,9 @@ connectionLimits:
   reservePoolSize: 25
   reservePoolTimeout: 5
 
+spec:
+    labels: {} # Add custom pod labels here
+
 labels: {}
 # Add custom deployment labels here
 


### PR DESCRIPTION
I added a snip to deployment template that will add labels to the kubernetes pod metadata. The object path is spec.labels.