### PR TITLE
Changing pgbouncer.ini generation to use key for setting name of

### DIFF
--- a/pgbouncer/templates/_pgbouncer.ini.tpl
+++ b/pgbouncer/templates/_pgbouncer.ini.tpl
@@ -8,9 +8,9 @@
 
 {{- $requiredMsg := printf ".Values.databases.%v needs to include .dbname" $k }}
 {{- if $root.Values.global.namespacedDatabases }}
-{{ required $requiredMsg $v.dbname }} = host={{ $v.host }} port={{ $v.port }} {{ if $v.user }}user={{ $v.user }}{{end}} dbname={{ $root.Release.Namespace | replace "-" "_"}}_{{ $v.dbname }}
+{{ $k }} = host={{ $v.host }} port={{ $v.port }} {{ if $v.user }}user={{ $v.user }}{{end}} dbname={{ $root.Release.Namespace | replace "-" "_"}}_{{ required $requiredMsg $v.dbname }}
 {{- else }}
-{{ required $requiredMsg $v.dbname }} = host={{ $v.host }} port={{ $v.port }} {{ if $v.user }}user={{ $v.user }}{{end}} dbname={{ $v.dbname }}
+{{ $k }} = host={{ $v.host }} port={{ $v.port }} {{ if $v.user }}user={{ $v.user }}{{end}} dbname={{ required $requiredMsg $v.dbname }}
 {{- end }}
 
 {{- end }}


### PR DESCRIPTION
pgbouncer databse entry.

This fixes an issue where you have multiple entries with the same dbname property