### PR TITLE
Add config options

### DIFF
--- a/pgbouncer/templates/deployment-pgbouncer.yaml
+++ b/pgbouncer/templates/deployment-pgbouncer.yaml
@@ -59,6 +59,10 @@ spec:
         nodeAffinity:
           {{- toYaml .Values.nodeAffinity | nindent 10 }}
         {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}

--- a/pgbouncer/templates/service.yaml
+++ b/pgbouncer/templates/service.yaml
@@ -17,7 +17,7 @@ spec:
   selector:
     {{ template "pgbouncer.appLabel" . }}
   ports:
-    - port: 5432
+    - port: {{ .Values.servicePort }}
       targetPort: {{ .Values.internalPort }}
       protocol: TCP
       name: postgres

--- a/pgbouncer/values.yaml
+++ b/pgbouncer/values.yaml
@@ -1,6 +1,7 @@
 # Deployment values for pgbouncer
 replicaCount: 1
 internalPort: 5432
+servicePort: 5432
 antiAffinity: soft
 nodeAffinity: {} # optionally define nodeAffinity
 tolerations: [] # optionally define tolerations

--- a/pgbouncer/values.yaml
+++ b/pgbouncer/values.yaml
@@ -5,6 +5,7 @@ servicePort: 5432
 antiAffinity: soft
 nodeAffinity: {} # optionally define nodeAffinity
 tolerations: [] # optionally define tolerations
+nodeSelector: {} # optionally define nodeSelector
 
 # Pool mode, needs to be one of session, transaction, statement
 poolMode: session


### PR DESCRIPTION
I just would like to add the option to configure the servicePort as well as nodeSelector in the helm chart.
I left the servicePort at 5432, but it would be more fitting to switch to 6432, as it is the pgbouncer default port.