### PR TITLE
Add missing chart names to index.yaml repository manifest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
           NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           SHA=$(sha256sum pgbouncer-${{ env.CHART_VERSION }}.tgz | head -n1 | cut -d " " -f1)
           pushd repos/stable
-          cat index.yaml | yq -y --arg now "$NOW" --arg digest "$SHA" '.entries.pgbouncer += [{"apiVersion":"v1", "created": $now, "description":"pgbouncer", "digest":$digest, "urls":["https://github.com/cradlepoint/kubernetes-helm-chart-pgbouncer/releases/download/v${{ env.CHART_VERSION }}/pgbouncer-${{ env.CHART_VERSION }}.tgz"], "version": "${{ env.CHART_VERSION }}"}]' > index.yaml.tmp
+          cat index.yaml | yq -y --arg now "$NOW" --arg digest "$SHA" '.entries.pgbouncer += [{"apiVersion":"v1", "created": $now, "description":"pgbouncer", "digest":$digest, "name":"pgbouncer", "urls":["https://github.com/cradlepoint/kubernetes-helm-chart-pgbouncer/releases/download/v${{ env.CHART_VERSION }}/pgbouncer-${{ env.CHART_VERSION }}.tgz"], "version": "${{ env.CHART_VERSION }}"}]' > index.yaml.tmp
           mv index.yaml.tmp index.yaml
           popd
 

--- a/repos/stable/index.yaml
+++ b/repos/stable/index.yaml
@@ -13,6 +13,7 @@ entries:
       created: '2020-10-23T23:39:53Z'
       description: pgbouncer
       digest: 04342fe0f20d746e2fff783b4d07dc63e6166a12401e4cb6b3062454ad0f86d3
+      name: pgbouncer
       urls:
         - https://github.com/cradlepoint/kubernetes-helm-chart-pgbouncer/releases/download/v1.0.7/pgbouncer-1.0.7.tgz
       version: 1.0.7
@@ -20,6 +21,7 @@ entries:
       created: '2020-12-18T19:28:23Z'
       description: pgbouncer
       digest: a009663f07c4ce65df5f4085533fcb68f1f95310e47f66cb49c40c21331dcd85
+      name: pgbouncer
       urls:
         - https://github.com/cradlepoint/kubernetes-helm-chart-pgbouncer/releases/download/v1.0.9/pgbouncer-1.0.9.tgz
       version: 1.0.9
@@ -27,6 +29,7 @@ entries:
       created: '2021-01-26T11:09:12Z'
       description: pgbouncer
       digest: 0ac5c5523a96a336cc0da03adadc30f0cb1fe9d338fa939b6dca377b1aee0a7f
+      name: pgbouncer
       urls:
         - https://github.com/cradlepoint/kubernetes-helm-chart-pgbouncer/releases/download/v1.0.10/pgbouncer-1.0.10.tgz
       version: 1.0.10
@@ -34,6 +37,7 @@ entries:
       created: '2021-02-11T03:23:51Z'
       description: pgbouncer
       digest: 9fe0fd82a3bb9a08965981f812713f2eec6c98a85d8746ed4cd1c522e0ba9ead
+      name: pgbouncer
       urls:
         - https://github.com/cradlepoint/kubernetes-helm-chart-pgbouncer/releases/download/v1.0.11/pgbouncer-1.0.11.tgz
       version: 1.0.11


### PR DESCRIPTION
See https://helm.sh/docs/topics/chart_repository/#create-a-chart-repository.

Prevents Helm errors like the following:

```
(⎈ minikube:default)➜  gatekeeper git:(dev) ✗ helm dep update
Getting updates for unmanaged Helm repositories...
index.go:339: skipping loading invalid entry for chart "pgbouncer" "1.0.11" from https://raw.githubusercontent.com/cradlepoint/kubernetes-helm-chart-pgbouncer/master/repos/stable/: validation: chart.metadata.name is required
index.go:339: skipping loading invalid entry for chart "pgbouncer" "1.0.10" from https://raw.githubusercontent.com/cradlepoint/kubernetes-helm-chart-pgbouncer/master/repos/stable/: validation: chart.metadata.name is required
index.go:339: skipping loading invalid entry for chart "pgbouncer" "1.0.9" from https://raw.githubusercontent.com/cradlepoint/kubernetes-helm-chart-pgbouncer/master/repos/stable/: validation: chart.metadata.name is required
index.go:339: skipping loading invalid entry for chart "pgbouncer" "1.0.7" from https://raw.githubusercontent.com/cradlepoint/kubernetes-helm-chart-pgbouncer/master/repos/stable/: validation: chart.metadata.name is required
...Successfully got an update from the "https://raw.githubusercontent.com/cradlepoint/kubernetes-helm-chart-pgbouncer/master/repos/stable/" chart repository
```