### PR TITLE
optional settings for adding TLS files via secret

### DIFF
--- a/pgbouncer/templates/deployment-pgbouncer.yaml
+++ b/pgbouncer/templates/deployment-pgbouncer.yaml
@@ -62,6 +62,11 @@ spec:
         - name: secret
           secret:
             secretName: {{ include "pgbouncer.fullname" . }}-secret
+        {{- if .Values.tlsSecret.enabled}}
+        - name: tls-secret
+          secret:
+            secretName: {{ .Values.tlsSecret.tlsSecretName}}
+        {{- end}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -90,6 +95,9 @@ spec:
               subPath: pgbouncer.ini
               mountPath: /etc/pgbouncer/pgbouncer.ini
               readOnly: true
+            {{- if .Values.tlsSecret.enabled }}
+            - name: tls-secret
+              mountPath: /etc/pgbouncer/tls
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-

--- a/pgbouncer/values.yaml
+++ b/pgbouncer/values.yaml
@@ -101,3 +101,9 @@ service:
 global:
   # optionally use namespace as dbname
   namespacedDatabases: false
+
+# optional secrets for mounting TLS certificates and key
+tlsSecret:
+  enabled: false
+  # the name of the secret storing the certificates and key
+  tlsSecretName: ""


### PR DESCRIPTION
Added two extra values to allow for connecting with a Kubernetes secret to mount TLS certificates/keys.  One value is a boolean to enable the mounting of the secret and files.  The value `tlsSecretName` is the name of the Kubernetes secret to be mounted.

The certs/keys from the secret are mounted in `/etc/pgbouncer/tls`.