### PR TITLE
Add support for existing userlist secret

### DIFF
--- a/pgbouncer/templates/_helpers.tpl
+++ b/pgbouncer/templates/_helpers.tpl
@@ -42,3 +42,25 @@ Selector labels
 app.kubernetes.io/name: {{ include "pgbouncer.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Get the users secret name.
+*/}}
+{{- define "pgbouncer.usersSecretName" -}}
+{{- if .Values.existingUsersSecret -}}
+{{- printf "%s" .Values.existingUsersSecret -}}
+{{- else -}}
+{{- printf "%s-secret-userlist-txt" (include "pgbouncer.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the users key to be retrieved from pgbouncer secret.
+*/}}
+{{- define "pgbouncer.usersSecretKey" -}}
+{{- if .Values.existingUsersSecretKey -}}
+{{- printf "%s" .Values.existingUsersSecretKey -}}
+{{- else -}}
+{{- printf "userlist.txt" -}}
+{{- end -}}
+{{- end -}}

--- a/pgbouncer/templates/configmap-pgbouncer-ini.yaml
+++ b/pgbouncer/templates/configmap-pgbouncer-ini.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "pgbouncer.fullname" . }}-config
+  labels:
+    {{- include "pgbouncer.labels" . | nindent 4 }}
+data:
+  pgbouncer.ini: |-
+{{ include "pgbouncer.ini.1.0.0" . | indent 4 }}

--- a/pgbouncer/templates/deployment-pgbouncer.yaml
+++ b/pgbouncer/templates/deployment-pgbouncer.yaml
@@ -59,9 +59,12 @@ spec:
         - name: {{ .Values.imagePullSecretName }}
       {{- end }}
       volumes:
-        - name: secret
+        - name: userssecret
           secret:
-            secretName: {{ include "pgbouncer.fullname" . }}-secret
+            secretName: {{ template "pgbouncer.usersSecretName" . }}
+        - name: config
+          configMap:
+            name: {{ template "pgbouncer.fullname" . }}-config
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -82,11 +85,11 @@ spec:
                 # https://freecontent.manning.com/handling-client-requests-properly-with-kubernetes/
                 command: ["/bin/sh","-c","sleep 5"]
           volumeMounts:
-            - name: secret
-              subPath: userlist.txt
+            - name: userssecret
+              subPath: {{ template "pgbouncer.usersSecretKey" . }}
               mountPath: /etc/pgbouncer/userlist.txt
               readOnly: true
-            - name: secret
+            - name: config
               subPath: pgbouncer.ini
               mountPath: /etc/pgbouncer/pgbouncer.ini
               readOnly: true

--- a/pgbouncer/templates/secret-pgbouncer-users.yaml
+++ b/pgbouncer/templates/secret-pgbouncer-users.yaml
@@ -1,12 +1,12 @@
+{{- if not .Values.existingUsersSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "pgbouncer.fullname" . }}-secret
+  name: {{ template "pgbouncer.usersSecretName" . }}
   labels:
     {{- include "pgbouncer.labels" . | nindent 4 }}
 type: Opaque
 data:
   userlist.txt: |-
 {{ include "userlist.txt.1.0.0" . | b64enc | indent 4 }}
-  pgbouncer.ini: |-
-{{ include "pgbouncer.ini.1.0.0" . | b64enc | indent 4 }}
+{{- end -}}

--- a/pgbouncer/values.yaml
+++ b/pgbouncer/values.yaml
@@ -35,6 +35,15 @@ databases: {}
 users: {}
 #  username: password
 
+# the name of an existing secret containg your user list
+# data format is:
+#     "username1" "password"
+#     "username2" "other-password"
+# existingUsersSecret: myuserlist-secret
+
+# the key containing the secret
+# existingUsersSecretKey: userlist.txt
+
 # Custom pgbouncer.ini
 settings:
   auth_type: plain


### PR DESCRIPTION
This pull request adds the ability to use an existing secret for the userlist. This is particularly useful when secrets are fetched from an external source (eg. when using vault-operator).

I also split the secret and the configuration in two.