### PR TITLE
Remove requirement on databases[].dbname

### DIFF
--- a/pgbouncer/templates/_pgbouncer.ini.tpl
+++ b/pgbouncer/templates/_pgbouncer.ini.tpl
@@ -10,7 +10,7 @@
 {{- if $root.Values.global.namespacedDatabases }}
 {{ $k }} = host={{ $v.host }} port={{ $v.port }} {{ if $v.user }}user={{ $v.user }}{{end}} {{ if $v.auth_user }}auth_user={{ $v.auth_user }}{{end}} dbname={{ $root.Release.Namespace | replace "-" "_"}}_{{ required $requiredMsg $v.dbname }}
 {{- else }}
-{{ $k }} = host={{ $v.host }} port={{ $v.port }} {{ if $v.user }}user={{ $v.user }}{{end}} {{ if $v.auth_user }}auth_user={{ $v.auth_user }}{{end}} dbname={{ required $requiredMsg $v.dbname }}
+{{ $k }} = host={{ $v.host }} port={{ $v.port }} {{ if $v.user }}user={{ $v.user }}{{end}} {{ if $v.auth_user }}auth_user={{ $v.auth_user }}{{end}} {{ if $v.dbname }}dbname={{ $v.dbname }}{{end}}
 {{- end }}
 
 {{- end }}


### PR DESCRIPTION
This is to allow using the fallback database as described in http://www.pgbouncer.org/config.html#section-databases.
However, it makes sense to enforce it when `namespacedDatabases` is set.