### PR TITLE
change image tag back to latest

### DIFF
--- a/pgbouncer/values.yaml
+++ b/pgbouncer/values.yaml
@@ -16,7 +16,7 @@ budget:
 
 image:
   repository: cradlepoint/pgbouncer
-  tag: 1.0.1
+  tag: latest 
   pullPolicy: Always
 
 imagePullSecrets: []


### PR DESCRIPTION
use `latest` since `1.0.1` is not valid.  doh!  `1.0.1` is correct.  closing