### PR TITLE
remove dash at beginning of template that brings in labels:{}

### DIFF
--- a/pgbouncer/templates/_helpers.tpl
+++ b/pgbouncer/templates/_helpers.tpl
@@ -29,7 +29,7 @@ Common labels
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ include "pgbouncer.chart" . }}
 {{- if .Values.labels }}
-{{- toYaml .Values.labels }}
+{{ toYaml .Values.labels }}
 {{- end }}
 {{ include "pgbouncer.selectorLabels" . }}
 {{- end }}


### PR DESCRIPTION
this dash removes the carriage-return on beginning of output of `{{ toYaml  .Values.labels }}` so the first label is actually rendered at the end of the `helm.sh/chart: xxx` label.