### PR TITLE
Enable backwards matchLabels backwards compatibility

### DIFF
--- a/pgbouncer/templates/_helpers.tpl
+++ b/pgbouncer/templates/_helpers.tpl
@@ -39,9 +39,13 @@ helm.sh/chart: {{ include "pgbouncer.chart" . }}
 Selector labels
 */}}
 {{- define "pgbouncer.selectorLabels" -}}
+{{- if .Values.helm2selector }}
+app: {{ include "pgbouncer.fullname" . }}
+release: {{ .Release.Name }}
+{{- else }}
 app.kubernetes.io/name: {{ include "pgbouncer.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-app: {{ include "pgbouncer.fullname" . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/pgbouncer/values.yaml
+++ b/pgbouncer/values.yaml
@@ -87,6 +87,10 @@ spec:
 # Add custom deployment labels here
 labels: {}
 
+# Whether to use helm2-style selectors.  Note pgbouncer version <= v1.0.10 defined the Deployment spec.template.matchLabels:{} this way,
+# so define this to true to upgrade an existing pgbouncer deployment of versions <= v1.0.10.
+helm2selector: false
+
 logConnections: 0
 logDisconnections: 0
 logStats: 0


### PR DESCRIPTION
`.Values.helm2selector=true` will cause Deployment matchLabels to be rendered same as v1.0.10 and earlier.
This enables upgrading existing pgbouncer installations of <= v1.0.10 since Deployment `spec.template.matchLabels:{}` is immutable.